### PR TITLE
fix: replace local path to network url

### DIFF
--- a/lib/features/videos/views/widgets/video_post.dart
+++ b/lib/features/videos/views/widgets/video_post.dart
@@ -56,7 +56,7 @@ class VideoPostState extends ConsumerState<VideoPost>
 
   void _initVideoPlayer() async {
     _videoPlayerController =
-        VideoPlayerController.asset("assets/videos/video.mp4");
+        VideoPlayerController.network(widget.videoData.fileUrl);
     await _videoPlayerController.initialize();
     await _videoPlayerController.setLooping(true);
     if (kIsWeb) {


### PR DESCRIPTION
I just realized VideoPlayerController was initialized with local path after watching lecture 3 times..

## Goal
- Not to be confused between local file and network url
- To see real-world service works

## Todo
- [x] fix: replace local path to network url